### PR TITLE
Add get_child_documents tool for child table queries

### DIFF
--- a/src/child-query.test.ts
+++ b/src/child-query.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildChildQueryArgs,
+  validateDocTypeName,
+  validateFieldName,
+  validateChildFilter,
+  DEFAULT_LIMIT,
+} from "./child-query.js";
+
+describe("validateDocTypeName", () => {
+  it("accepts normal DocType names", () => {
+    expect(() => validateDocTypeName("BOM", "test")).not.toThrow();
+    expect(() => validateDocTypeName("BOM Item", "test")).not.toThrow();
+    expect(() => validateDocTypeName("Purchase Order Item", "test")).not.toThrow();
+    expect(() => validateDocTypeName("Sales-Order", "test")).not.toThrow();
+  });
+
+  it("rejects names with special characters", () => {
+    expect(() => validateDocTypeName("BOM; DROP TABLE", "test")).toThrow("Invalid test");
+    expect(() => validateDocTypeName("Item`", "test")).toThrow("Invalid test");
+    expect(() => validateDocTypeName("Item\nCode", "test")).toThrow("Invalid test");
+  });
+});
+
+describe("validateFieldName", () => {
+  it("accepts valid field names", () => {
+    expect(() => validateFieldName("item_code", "test")).not.toThrow();
+    expect(() => validateFieldName("qty", "test")).not.toThrow();
+    expect(() => validateFieldName("name", "test")).not.toThrow();
+  });
+
+  it("rejects field names with special characters", () => {
+    expect(() => validateFieldName("item code", "test")).toThrow("Invalid field");
+    expect(() => validateFieldName("item;DROP", "test")).toThrow("Invalid field");
+    expect(() => validateFieldName("rate`", "test")).toThrow("Invalid field");
+  });
+});
+
+describe("validateChildFilter", () => {
+  it("accepts valid 3-tuple filters", () => {
+    expect(() => validateChildFilter(["item_code", "like", "%CM5%"])).not.toThrow();
+    expect(() => validateChildFilter(["qty", ">", "0"])).not.toThrow();
+  });
+
+  it("rejects non-array", () => {
+    expect(() => validateChildFilter("item_code")).toThrow("expected [field, operator, value]");
+  });
+
+  it("rejects wrong length", () => {
+    expect(() => validateChildFilter(["field", "="])).toThrow("expected [field, operator, value]");
+    expect(() => validateChildFilter(["a", "b", "c", "d"])).toThrow(
+      "expected [field, operator, value]",
+    );
+  });
+
+  it("rejects non-string elements", () => {
+    expect(() => validateChildFilter(["field", "=", 123])).toThrow(
+      "expected [field, operator, value]",
+    );
+  });
+});
+
+describe("buildChildQueryArgs", () => {
+  it("builds minimal args with defaults", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+    });
+    expect(args.doctype).toBe("BOM");
+    expect(args.fields).toEqual(["name"]);
+    expect(args.limit_page_length).toBe(DEFAULT_LIMIT);
+    expect(args.filters).toBeUndefined();
+  });
+
+  it("includes parent and child fields", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      parentFields: ["name", "total_cost"],
+      childFields: ["item_code", "qty"],
+    });
+    expect(args.fields).toEqual([
+      "name",
+      "total_cost",
+      "`tabBOM Item`.item_code",
+      "`tabBOM Item`.qty",
+    ]);
+  });
+
+  it("transforms child filters from 3-tuple to 4-tuple", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      childFilters: [["item_code", "like", "%CM5%"]],
+    });
+    expect(args.filters).toEqual([["BOM Item", "item_code", "like", "%CM5%"]]);
+  });
+
+  it("applies parent_filters with implicit = operator", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      parentFilters: { is_active: 1 },
+    });
+    expect(args.filters).toEqual([["BOM", "is_active", "=", 1]]);
+  });
+
+  it("applies parent_filters with explicit operator", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      parentFilters: { docstatus: ["=", "1"] },
+    });
+    expect(args.filters).toEqual([["BOM", "docstatus", "=", "1"]]);
+  });
+
+  it("merges child and parent filters", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      childFilters: [["item_code", "like", "%CM5%"]],
+      parentFilters: { is_active: 1 },
+    });
+    expect(args.filters).toEqual([
+      ["BOM Item", "item_code", "like", "%CM5%"],
+      ["BOM", "is_active", "=", 1],
+    ]);
+  });
+
+  it("uses custom limit when provided", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      limit: 50,
+    });
+    expect(args.limit_page_length).toBe(50);
+  });
+
+  it("rejects invalid parent doctype", () => {
+    expect(() =>
+      buildChildQueryArgs({
+        parentDoctype: "BOM; DROP TABLE",
+        childDoctype: "BOM Item",
+      }),
+    ).toThrow("Invalid parent_doctype");
+  });
+
+  it("rejects invalid child field names", () => {
+    expect(() =>
+      buildChildQueryArgs({
+        parentDoctype: "BOM",
+        childDoctype: "BOM Item",
+        childFields: ["item_code; DROP TABLE"],
+      }),
+    ).toThrow("Invalid field name in child_fields");
+  });
+
+  it("rejects malformed child_filters", () => {
+    expect(() =>
+      buildChildQueryArgs({
+        parentDoctype: "BOM",
+        childDoctype: "BOM Item",
+        childFilters: [["field", "="] as unknown as [string, string, string]],
+      }),
+    ).toThrow("expected [field, operator, value]");
+  });
+});

--- a/src/child-query.ts
+++ b/src/child-query.ts
@@ -1,0 +1,107 @@
+type AnyRecord = Record<string, any>;
+
+// ERPNext field names: word characters only (letters, digits, underscore)
+const FIELD_NAME_RE = /^\w+$/;
+// ERPNext DocType names: letters, digits, spaces, hyphens, underscores
+const DOCTYPE_NAME_RE = /^[\w -]+$/;
+
+export function validateDocTypeName(name: string, label: string): void {
+  if (!DOCTYPE_NAME_RE.test(name)) {
+    throw new Error(`Invalid ${label}: ${JSON.stringify(name)}`);
+  }
+}
+
+export function validateFieldName(name: string, label: string): void {
+  if (!FIELD_NAME_RE.test(name)) {
+    throw new Error(`Invalid field name in ${label}: ${JSON.stringify(name)}`);
+  }
+}
+
+export function validateChildFilter(filter: unknown): asserts filter is [string, string, string] {
+  if (
+    !Array.isArray(filter) ||
+    filter.length !== 3 ||
+    !filter.every((v) => typeof v === "string")
+  ) {
+    throw new Error(
+      `Invalid child_filter entry: expected [field, operator, value] triple, got ${JSON.stringify(filter)}`,
+    );
+  }
+}
+
+export interface ChildQueryArgs {
+  parentDoctype: string;
+  childDoctype: string;
+  parentFields?: string[];
+  childFields?: string[];
+  childFilters?: Array<[string, string, string]>;
+  parentFilters?: AnyRecord;
+  limit?: number;
+}
+
+export const DEFAULT_LIMIT = 100;
+
+/**
+ * Convert {field: value} filter object to Frappe 4-tuple filter list.
+ * Values can be scalars (implies "=" operator) or [operator, value] arrays.
+ */
+function parentFiltersToTuples(
+  doctype: string,
+  filters: AnyRecord,
+): Array<[string, string, string, unknown]> {
+  return Object.entries(filters).map(([field, value]) => {
+    validateFieldName(field, "parent_filters field");
+    if (Array.isArray(value) && value.length === 2 && typeof value[0] === "string") {
+      return [doctype, field, value[0], value[1]];
+    }
+    return [doctype, field, "=", value];
+  });
+}
+
+/**
+ * Build the args object for frappe.client.get_list to query child table rows
+ * via a parent-child join.
+ */
+export function buildChildQueryArgs(input: ChildQueryArgs): AnyRecord {
+  validateDocTypeName(input.parentDoctype, "parent_doctype");
+  validateDocTypeName(input.childDoctype, "child_doctype");
+
+  const resolvedParentFields = input.parentFields || ["name"];
+  resolvedParentFields.forEach((f) => validateFieldName(f, "parent_fields"));
+
+  const resolvedChildFields = input.childFields || [];
+  resolvedChildFields.forEach((f) => validateFieldName(f, "child_fields"));
+
+  if (input.childFilters) {
+    input.childFilters.forEach((filter) => {
+      validateChildFilter(filter);
+      validateFieldName(filter[0], "child_filters field");
+    });
+  }
+
+  // Frappe convention: database table name is `tab{DocType}`
+  const childTable = `tab${input.childDoctype}`;
+  const fields: string[] = [
+    ...resolvedParentFields,
+    ...resolvedChildFields.map((f) => `\`${childTable}\`.${f}`),
+  ];
+
+  const childFilterTuples: Array<[string, string, string, string]> = (input.childFilters || []).map(
+    ([field, op, value]) => [input.childDoctype, field, op, value],
+  );
+
+  const parentFilterTuples = input.parentFilters
+    ? parentFiltersToTuples(input.parentDoctype, input.parentFilters)
+    : [];
+
+  const allFilters = [...childFilterTuples, ...parentFilterTuples];
+
+  const args: AnyRecord = {
+    doctype: input.parentDoctype,
+    fields,
+    limit_page_length: input.limit ?? DEFAULT_LIMIT,
+  };
+  if (allFilters.length) args.filters = allFilters;
+
+  return args;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import axios, { AxiosInstance } from "axios";
+import { buildChildQueryArgs } from "./child-query.js";
 import { stripDocument } from "./strip.js";
 
 type AnyRecord = Record<string, any>;
@@ -102,6 +103,28 @@ class ERPNextClient {
     } catch (error: any) {
       throw new Error(`Failed to get ${doctype} list: ${error?.message || "Unknown error"}`);
     }
+  }
+
+  async getChildDocList(
+    parentDoctype: string,
+    childDoctype: string,
+    parentFields?: string[],
+    childFields?: string[],
+    childFilters?: Array<[string, string, string]>,
+    parentFilters?: AnyRecord,
+    limit?: number,
+  ): Promise<any[]> {
+    const args = buildChildQueryArgs({
+      parentDoctype,
+      childDoctype,
+      parentFields,
+      childFields,
+      childFilters,
+      parentFilters,
+      limit,
+    });
+    const result = await this.callMethod("frappe.client.get_list", args);
+    return result || [];
   }
 
   async createDocument(doctype: string, doc: AnyRecord): Promise<any> {
@@ -384,6 +407,59 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "get_child_documents",
+        description:
+          "Query child table rows by joining parent and child DocTypes. Direct child table queries return 403; this tool queries the parent DocType with child table field joins. Returns one row per matching child table row.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            parent_doctype: {
+              type: "string",
+              description: "Parent DocType (e.g., BOM, Purchase Order, Sales Order)",
+            },
+            child_doctype: {
+              type: "string",
+              description:
+                "Child table DocType (e.g., BOM Item, Purchase Order Item, Sales Order Item)",
+            },
+            parent_fields: {
+              type: "array",
+              items: { type: "string" },
+              description:
+                'Fields from the parent document (e.g., ["name", "item", "total_cost"]). Defaults to ["name"].',
+            },
+            child_fields: {
+              type: "array",
+              items: { type: "string" },
+              description:
+                'Fields from the child table (e.g., ["item_code", "qty", "rate"]). Automatically prefixed with child table reference.',
+            },
+            child_filters: {
+              type: "array",
+              items: {
+                type: "array",
+                items: { type: "string" },
+                minItems: 3,
+                maxItems: 3,
+              },
+              description:
+                'Filters on child table fields as [field, operator, value] triples (e.g., [["item_code", "like", "%CM5%"]])',
+            },
+            parent_filters: {
+              type: "object",
+              additionalProperties: true,
+              description:
+                'Filters on parent document fields, same format as get_documents filters (e.g., {"is_active": 1, "docstatus": ["=", "1"]})',
+            },
+            limit: {
+              type: "number",
+              description: "Maximum number of rows to return (default: 100)",
+            },
+          },
+          required: ["parent_doctype", "child_doctype"],
+        },
+      },
+      {
         name: "create_document",
         description: "Create a new document in ERPNext",
         inputSchema: {
@@ -583,6 +659,55 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text: `Failed to get ${doctype} documents: ${error?.message || "Unknown error"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "get_child_documents": {
+      const parentDoctype = request.params.arguments?.parent_doctype;
+      const childDoctype = request.params.arguments?.child_doctype;
+      if (
+        typeof parentDoctype !== "string" ||
+        !parentDoctype ||
+        typeof childDoctype !== "string" ||
+        !childDoctype
+      ) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          "parent_doctype and child_doctype are required",
+        );
+      }
+
+      const parentFields = request.params.arguments?.parent_fields as string[] | undefined;
+      const childFields = request.params.arguments?.child_fields as string[] | undefined;
+      const childFilters = request.params.arguments?.child_filters as
+        | Array<[string, string, string]>
+        | undefined;
+      const parentFilters = request.params.arguments?.parent_filters as AnyRecord | undefined;
+      const limit = request.params.arguments?.limit as number | undefined;
+
+      try {
+        const rows = await erpnext.getChildDocList(
+          parentDoctype,
+          childDoctype,
+          parentFields,
+          childFields,
+          childFilters,
+          parentFilters,
+          limit,
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify(rows) }],
+        };
+      } catch (error: any) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to get ${childDoctype} from ${parentDoctype}: ${error?.message || "Unknown error"}`,
             },
           ],
           isError: true,


### PR DESCRIPTION
## Summary

- Adds `get_child_documents` MCP tool that queries child table DocTypes (BOM Item, Purchase Order Item, etc.) which return 403 when accessed directly via the REST API
- Works by querying the parent DocType with backtick-joined child table fields and list-style child filters through `frappe.client.get_list`
- Accepts `parent_doctype`, `child_doctype`, `parent_fields`, `child_fields`, `child_filters`, and `limit` parameters

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] Verified `frappe.client.get_list` on child DocTypes directly returns 403
- [x] Verified parent-join approach works for BOM Item queries (filter by item_code)
- [x] Verified parent-join approach works for Purchase Order Item queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)