### PR TITLE
fix(get_child_documents): handle non-array field inputs at runtime boundary

### DIFF
--- a/src/child-query.test.ts
+++ b/src/child-query.test.ts
@@ -164,4 +164,52 @@ describe("buildChildQueryArgs", () => {
       }),
     ).toThrow("expected [field, operator, value]");
   });
+
+  it("coerces empty parentFields array to default ['name']", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "Purchase Order",
+      childDoctype: "Purchase Taxes and Charges",
+      parentFields: [],
+      childFields: ["account_head"],
+    });
+    expect(args.fields).toEqual(["name", "`tabPurchase Taxes and Charges`.account_head"]);
+  });
+
+  it("coerces string parentFields to array", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      parentFields: "total_cost" as unknown as string[],
+      childFields: ["item_code"],
+    });
+    expect(args.fields).toEqual(["total_cost", "`tabBOM Item`.item_code"]);
+  });
+
+  it("handles non-array parentFields gracefully", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      parentFields: 42 as unknown as string[],
+    });
+    expect(args.fields).toEqual(["name"]);
+  });
+
+  it("coerces string childFields to array", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      childFields: "item_code" as unknown as string[],
+    });
+    expect(args.fields).toEqual(["name", "`tabBOM Item`.item_code"]);
+  });
+
+  it("handles non-array childFilters with error", () => {
+    expect(() =>
+      buildChildQueryArgs({
+        parentDoctype: "BOM",
+        childDoctype: "BOM Item",
+        childFilters: "not an array" as unknown as Array<[string, string, string]>,
+      }),
+    ).toThrow("Invalid child_filters");
+  });
 });

--- a/src/child-query.ts
+++ b/src/child-query.ts
@@ -32,11 +32,37 @@ export function validateChildFilter(filter: unknown): asserts filter is [string,
 export interface ChildQueryArgs {
   parentDoctype: string;
   childDoctype: string;
-  parentFields?: string[];
-  childFields?: string[];
-  childFilters?: Array<[string, string, string]>;
+  parentFields?: unknown;
+  childFields?: unknown;
+  childFilters?: unknown;
   parentFilters?: AnyRecord;
   limit?: number;
+}
+
+/**
+ * Coerce an unknown value to a string array.
+ * Handles: undefined/null → undefined, string → [string], array → array, other → undefined.
+ */
+function toStringArray(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.map(String);
+  return undefined;
+}
+
+/**
+ * Coerce an unknown value to an array of [string, string, string] filter triples.
+ * Each element is validated by validateChildFilter.
+ */
+function toFilterArray(value: unknown): Array<[string, string, string]> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `Invalid child_filters: expected array of [field, operator, value] triples, got ${typeof value}`,
+    );
+  }
+  value.forEach((f) => validateChildFilter(f));
+  return value as Array<[string, string, string]>;
 }
 
 export const DEFAULT_LIMIT = 100;
@@ -66,15 +92,17 @@ export function buildChildQueryArgs(input: ChildQueryArgs): AnyRecord {
   validateDocTypeName(input.parentDoctype, "parent_doctype");
   validateDocTypeName(input.childDoctype, "child_doctype");
 
-  const resolvedParentFields = input.parentFields || ["name"];
+  const coercedParentFields = toStringArray(input.parentFields);
+  const resolvedParentFields =
+    coercedParentFields && coercedParentFields.length > 0 ? coercedParentFields : ["name"];
   resolvedParentFields.forEach((f) => validateFieldName(f, "parent_fields"));
 
-  const resolvedChildFields = input.childFields || [];
+  const resolvedChildFields = toStringArray(input.childFields) || [];
   resolvedChildFields.forEach((f) => validateFieldName(f, "child_fields"));
 
-  if (input.childFilters) {
-    input.childFilters.forEach((filter) => {
-      validateChildFilter(filter);
+  const resolvedChildFilters = toFilterArray(input.childFilters);
+  if (resolvedChildFilters) {
+    resolvedChildFilters.forEach((filter) => {
       validateFieldName(filter[0], "child_filters field");
     });
   }
@@ -86,9 +114,9 @@ export function buildChildQueryArgs(input: ChildQueryArgs): AnyRecord {
     ...resolvedChildFields.map((f) => `\`${childTable}\`.${f}`),
   ];
 
-  const childFilterTuples: Array<[string, string, string, string]> = (input.childFilters || []).map(
-    ([field, op, value]) => [input.childDoctype, field, op, value],
-  );
+  const childFilterTuples: Array<[string, string, string, string]> = (
+    resolvedChildFilters || []
+  ).map(([field, op, value]) => [input.childDoctype, field, op, value]);
 
   const parentFilterTuples = input.parentFilters
     ? parentFiltersToTuples(input.parentDoctype, input.parentFilters)

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,9 +108,9 @@ class ERPNextClient {
   async getChildDocList(
     parentDoctype: string,
     childDoctype: string,
-    parentFields?: string[],
-    childFields?: string[],
-    childFilters?: Array<[string, string, string]>,
+    parentFields?: unknown,
+    childFields?: unknown,
+    childFilters?: unknown,
     parentFilters?: AnyRecord,
     limit?: number,
   ): Promise<any[]> {


### PR DESCRIPTION
## Summary
- Add runtime type coercion for `parentFields`, `childFields`, and `childFilters` in `buildChildQueryArgs`
- Strings become single-element arrays, empty arrays fall back to defaults, invalid types handled gracefully
- Widens `ChildQueryArgs` interface to accept `unknown` types at the MCP protocol boundary

## Test plan
- [x] New unit tests: empty array, string, non-array coercion for parentFields/childFields/childFilters
- [x] All 40 existing tests pass
- [ ] Manual test: `get_child_documents` with `parent_fields=[]` no longer crashes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)