### PR TITLE
fix: coerce stringified JSON inputs from MCP SDK to prevent double-encoding

### DIFF
--- a/src/coerce.test.ts
+++ b/src/coerce.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { coerceStringArray, coerceObject, coerceNumber } from "./coerce.js";
+
+describe("coerceStringArray", () => {
+  it("returns undefined for undefined/null", () => {
+    expect(coerceStringArray(undefined)).toBeUndefined();
+    expect(coerceStringArray(null)).toBeUndefined();
+  });
+
+  it("passes through arrays", () => {
+    expect(coerceStringArray(["name", "item_code"])).toEqual(["name", "item_code"]);
+  });
+
+  it("parses JSON string arrays", () => {
+    expect(coerceStringArray('["name", "account_name"]')).toEqual(["name", "account_name"]);
+  });
+
+  it("wraps plain strings as single-element array", () => {
+    expect(coerceStringArray("name")).toEqual(["name"]);
+  });
+
+  it("returns undefined for non-array/string types", () => {
+    expect(coerceStringArray(42)).toBeUndefined();
+    expect(coerceStringArray({})).toBeUndefined();
+  });
+});
+
+describe("coerceObject", () => {
+  it("returns undefined for undefined/null", () => {
+    expect(coerceObject(undefined)).toBeUndefined();
+    expect(coerceObject(null)).toBeUndefined();
+  });
+
+  it("passes through objects", () => {
+    expect(coerceObject({ account_number: "5205" })).toEqual({ account_number: "5205" });
+  });
+
+  it("parses JSON string objects", () => {
+    expect(coerceObject('{"account_number": "5205"}')).toEqual({ account_number: "5205" });
+  });
+
+  it("parses nested filter values", () => {
+    expect(coerceObject('{"name": ["like", "%5205%"]}')).toEqual({ name: ["like", "%5205%"] });
+  });
+
+  it("returns undefined for arrays", () => {
+    expect(coerceObject([1, 2, 3])).toBeUndefined();
+  });
+
+  it("returns undefined for JSON arrays in strings", () => {
+    expect(coerceObject('["name"]')).toBeUndefined();
+  });
+
+  it("returns undefined for invalid JSON strings", () => {
+    expect(coerceObject("not json")).toBeUndefined();
+  });
+
+  it("handles empty object string", () => {
+    expect(coerceObject("{}")).toEqual({});
+  });
+});
+
+describe("coerceNumber", () => {
+  it("returns undefined for undefined/null", () => {
+    expect(coerceNumber(undefined)).toBeUndefined();
+    expect(coerceNumber(null)).toBeUndefined();
+  });
+
+  it("passes through numbers", () => {
+    expect(coerceNumber(5)).toBe(5);
+  });
+
+  it("parses numeric strings", () => {
+    expect(coerceNumber("5")).toBe(5);
+    expect(coerceNumber("100")).toBe(100);
+  });
+
+  it("returns undefined for non-numeric strings", () => {
+    expect(coerceNumber("abc")).toBeUndefined();
+  });
+});

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -1,0 +1,59 @@
+/**
+ * Input coercion for MCP tool arguments.
+ *
+ * The MCP SDK sometimes passes JSON-serialized strings instead of parsed
+ * objects/arrays. These helpers parse stringified inputs back to their
+ * expected types, preventing double-encoding when the values are later
+ * passed to JSON.stringify() for API calls.
+ */
+
+/**
+ * Coerce a value to a string array.
+ * Handles: string (JSON-parse or wrap), array (pass-through), undefined/null.
+ */
+export function coerceStringArray(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      /* not JSON — wrap as single-element array */
+    }
+    return [value];
+  }
+  return undefined;
+}
+
+/**
+ * Coerce a value to a plain object.
+ * Handles: string (JSON-parse), object (pass-through), undefined/null.
+ */
+export function coerceObject(value: unknown): Record<string, any> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, any>;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) return parsed;
+    } catch {
+      /* not valid JSON object */
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Coerce a value to a number.
+ * Handles: number (pass-through), string (parse), undefined/null.
+ */
+export function coerceNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (!isNaN(n)) return n;
+  }
+  return undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios, { AxiosInstance } from "axios";
 import { buildChildQueryArgs } from "./child-query.js";
+import { coerceStringArray, coerceObject, coerceNumber } from "./coerce.js";
 import { stripDocument } from "./strip.js";
 
 type AnyRecord = Record<string, any>;
@@ -108,18 +109,20 @@ class ERPNextClient {
   async getChildDocList(
     parentDoctype: string,
     childDoctype: string,
-    parentFields?: string[],
-    childFields?: string[],
-    childFilters?: Array<[string, string, string]>,
+    parentFields?: unknown,
+    childFields?: unknown,
+    childFilters?: unknown,
     parentFilters?: AnyRecord,
     limit?: number,
   ): Promise<any[]> {
+    // Type casts are safe: buildChildQueryArgs validates at runtime.
+    // ChildQueryArgs will accept unknown directly after PR #10 merges.
     const args = buildChildQueryArgs({
       parentDoctype,
       childDoctype,
-      parentFields,
-      childFields,
-      childFilters,
+      parentFields: parentFields as string[] | undefined,
+      childFields: childFields as string[] | undefined,
+      childFilters: childFilters as Array<[string, string, string]> | undefined,
       parentFilters,
       limit,
     });
@@ -644,9 +647,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new McpError(ErrorCode.InvalidParams, "Doctype is required");
       }
 
-      const fields = request.params.arguments?.fields as string[] | undefined;
-      const filters = request.params.arguments?.filters as AnyRecord | undefined;
-      const limit = request.params.arguments?.limit as number | undefined;
+      const fields = coerceStringArray(request.params.arguments?.fields);
+      const filters = coerceObject(request.params.arguments?.filters);
+      const limit = coerceNumber(request.params.arguments?.limit);
 
       try {
         const documents = await erpnext.getDocList(doctype, filters, fields, limit);
@@ -681,13 +684,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         );
       }
 
-      const parentFields = request.params.arguments?.parent_fields as string[] | undefined;
-      const childFields = request.params.arguments?.child_fields as string[] | undefined;
-      const childFilters = request.params.arguments?.child_filters as
-        | Array<[string, string, string]>
-        | undefined;
-      const parentFilters = request.params.arguments?.parent_filters as AnyRecord | undefined;
-      const limit = request.params.arguments?.limit as number | undefined;
+      const parentFields = request.params.arguments?.parent_fields;
+      const childFields = request.params.arguments?.child_fields;
+      const childFilters = request.params.arguments?.child_filters;
+      const parentFilters = coerceObject(request.params.arguments?.parent_filters);
+      const limit = coerceNumber(request.params.arguments?.limit);
 
       try {
         const rows = await erpnext.getChildDocList(
@@ -717,7 +718,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "create_document": {
       const doctype = request.params.arguments?.doctype;
-      const data = request.params.arguments?.data as AnyRecord | undefined;
+      const data = coerceObject(request.params.arguments?.data);
       if (typeof doctype !== "string" || !doctype || !data) {
         throw new McpError(ErrorCode.InvalidParams, "Doctype and data are required");
       }
@@ -753,7 +754,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case "update_document": {
       const doctype = request.params.arguments?.doctype;
       const name = request.params.arguments?.name;
-      const data = request.params.arguments?.data as AnyRecord | undefined;
+      const data = coerceObject(request.params.arguments?.data);
       if (typeof doctype !== "string" || !doctype || typeof name !== "string" || !name || !data) {
         throw new McpError(ErrorCode.InvalidParams, "Doctype, name, and data are required");
       }
@@ -792,7 +793,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new McpError(ErrorCode.InvalidParams, "Report name is required");
       }
 
-      const filters = request.params.arguments?.filters as AnyRecord | undefined;
+      const filters = coerceObject(request.params.arguments?.filters);
 
       try {
         const result = await erpnext.runReport(reportName, filters);
@@ -866,7 +867,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new McpError(ErrorCode.InvalidParams, "Method is required");
       }
 
-      const args = request.params.arguments?.args as AnyRecord | undefined;
+      const args = coerceObject(request.params.arguments?.args);
       const httpMethod = (request.params.arguments?.http_method === "GET" ? "GET" : "POST") as
         | "GET"
         | "POST";


### PR DESCRIPTION
## Summary
- MCP SDK sometimes passes `filters`, `fields`, and `data` as JSON strings instead of parsed objects/arrays
- When these strings hit `JSON.stringify()` in API methods, they get double-encoded (e.g., `"{\"key\":\"val\"}"` → `"\"{\\\"key\\\":\\\"val\\\"}\""`), causing ERPNext to reject with 417
- Add `coerceStringArray()`, `coerceObject()`, `coerceNumber()` helpers that parse string inputs back to expected types
- Applied at the tool handler boundary for all tools that accept complex inputs

## Root cause
Found by examining session logs — the failing tool calls were:
```json
"filters": "{\"account_number\": \"5205\"}"   // string, not object
"fields": "[\"name\", \"account_name\"]"       // string, not array
```

## Test plan
- [x] 17 unit tests for coercion helpers
- [x] All 52 tests pass
- [ ] Manual test: `get_documents` with Account DocType works correctly

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)