### PR TITLE
fix: coerce stringified MCP SDK inputs to prevent double-encoding

### DIFF
--- a/src/child-query.test.ts
+++ b/src/child-query.test.ts
@@ -42,6 +42,11 @@ describe("validateChildFilter", () => {
     expect(() => validateChildFilter(["qty", ">", "0"])).not.toThrow();
   });
 
+  it("accepts numeric filter values", () => {
+    expect(() => validateChildFilter(["qty", ">", 10])).not.toThrow();
+    expect(() => validateChildFilter(["docstatus", "=", 1])).not.toThrow();
+  });
+
   it("rejects non-array", () => {
     expect(() => validateChildFilter("item_code")).toThrow("expected [field, operator, value]");
   });
@@ -53,8 +58,11 @@ describe("validateChildFilter", () => {
     );
   });
 
-  it("rejects non-string elements", () => {
-    expect(() => validateChildFilter(["field", "=", 123])).toThrow(
+  it("rejects non-string field or operator", () => {
+    expect(() => validateChildFilter([123, "=", "val"])).toThrow(
+      "expected [field, operator, value]",
+    );
+    expect(() => validateChildFilter(["field", 42, "val"])).toThrow(
       "expected [field, operator, value]",
     );
   });
@@ -163,5 +171,61 @@ describe("buildChildQueryArgs", () => {
         childFilters: [["field", "="] as unknown as [string, string, string]],
       }),
     ).toThrow("expected [field, operator, value]");
+  });
+
+  it("coerces JSON string parentFields", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      parentFields: '["name", "total_cost"]',
+    });
+    expect(args.fields).toContain("name");
+    expect(args.fields).toContain("total_cost");
+  });
+
+  it("coerces JSON string childFields", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      childFields: '["item_code", "qty"]',
+    });
+    expect(args.fields).toContain("`tabBOM Item`.item_code");
+    expect(args.fields).toContain("`tabBOM Item`.qty");
+  });
+
+  it("coerces JSON string childFilters", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      childFilters: '[["item_code", "like", "%CM5%"]]',
+    });
+    expect(args.filters).toEqual([["BOM Item", "item_code", "like", "%CM5%"]]);
+  });
+
+  it("coerces JSON string parentFilters", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      parentFilters: '{"is_active": 1}',
+    });
+    expect(args.filters).toEqual([["BOM", "is_active", "=", 1]]);
+  });
+
+  it("coerces string limit", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      limit: "50",
+    });
+    expect(args.limit_page_length).toBe(50);
+  });
+
+  it("defaults parentFields to ['name'] when empty array", () => {
+    const args = buildChildQueryArgs({
+      parentDoctype: "BOM",
+      childDoctype: "BOM Item",
+      parentFields: [],
+    });
+    expect(args.fields).toEqual(["name"]);
   });
 });

--- a/src/child-query.ts
+++ b/src/child-query.ts
@@ -1,3 +1,5 @@
+import { coerceStringArray, coerceObject, coerceNumber, coerceFilterArray } from "./coerce.js";
+
 type AnyRecord = Record<string, any>;
 
 // ERPNext field names: word characters only (letters, digits, underscore)
@@ -17,11 +19,12 @@ export function validateFieldName(name: string, label: string): void {
   }
 }
 
-export function validateChildFilter(filter: unknown): asserts filter is [string, string, string] {
+export function validateChildFilter(filter: unknown): asserts filter is [string, string, unknown] {
   if (
     !Array.isArray(filter) ||
     filter.length !== 3 ||
-    !filter.every((v) => typeof v === "string")
+    typeof filter[0] !== "string" ||
+    typeof filter[1] !== "string"
   ) {
     throw new Error(
       `Invalid child_filter entry: expected [field, operator, value] triple, got ${JSON.stringify(filter)}`,
@@ -29,14 +32,18 @@ export function validateChildFilter(filter: unknown): asserts filter is [string,
   }
 }
 
+/**
+ * Raw input from MCP tool arguments — values may be JSON strings due to
+ * MCP SDK serialization. Coerced to typed values in buildChildQueryArgs.
+ */
 export interface ChildQueryArgs {
   parentDoctype: string;
   childDoctype: string;
-  parentFields?: string[];
-  childFields?: string[];
-  childFilters?: Array<[string, string, string]>;
-  parentFilters?: AnyRecord;
-  limit?: number;
+  parentFields?: unknown;
+  childFields?: unknown;
+  childFilters?: unknown;
+  parentFilters?: unknown;
+  limit?: unknown;
 }
 
 export const DEFAULT_LIMIT = 100;
@@ -66,18 +73,24 @@ export function buildChildQueryArgs(input: ChildQueryArgs): AnyRecord {
   validateDocTypeName(input.parentDoctype, "parent_doctype");
   validateDocTypeName(input.childDoctype, "child_doctype");
 
-  const resolvedParentFields = input.parentFields || ["name"];
+  const coercedParentFields = coerceStringArray(input.parentFields);
+  const resolvedParentFields =
+    coercedParentFields && coercedParentFields.length > 0 ? coercedParentFields : ["name"];
   resolvedParentFields.forEach((f) => validateFieldName(f, "parent_fields"));
 
-  const resolvedChildFields = input.childFields || [];
+  const resolvedChildFields = coerceStringArray(input.childFields) || [];
   resolvedChildFields.forEach((f) => validateFieldName(f, "child_fields"));
 
-  if (input.childFilters) {
-    input.childFilters.forEach((filter) => {
+  const coercedChildFilters = coerceFilterArray(input.childFilters);
+  if (coercedChildFilters) {
+    coercedChildFilters.forEach((filter) => {
       validateChildFilter(filter);
       validateFieldName(filter[0], "child_filters field");
     });
   }
+
+  const coercedParentFilters = coerceObject(input.parentFilters);
+  const coercedLimit = coerceNumber(input.limit);
 
   // Frappe convention: database table name is `tab{DocType}`
   const childTable = `tab${input.childDoctype}`;
@@ -86,12 +99,12 @@ export function buildChildQueryArgs(input: ChildQueryArgs): AnyRecord {
     ...resolvedChildFields.map((f) => `\`${childTable}\`.${f}`),
   ];
 
-  const childFilterTuples: Array<[string, string, string, string]> = (input.childFilters || []).map(
-    ([field, op, value]) => [input.childDoctype, field, op, value],
-  );
+  const childFilterTuples: Array<[string, string, string, unknown]> = (
+    coercedChildFilters || []
+  ).map(([field, op, value]) => [input.childDoctype, field, op, value]);
 
-  const parentFilterTuples = input.parentFilters
-    ? parentFiltersToTuples(input.parentDoctype, input.parentFilters)
+  const parentFilterTuples = coercedParentFilters
+    ? parentFiltersToTuples(input.parentDoctype, coercedParentFilters)
     : [];
 
   const allFilters = [...childFilterTuples, ...parentFilterTuples];
@@ -99,7 +112,7 @@ export function buildChildQueryArgs(input: ChildQueryArgs): AnyRecord {
   const args: AnyRecord = {
     doctype: input.parentDoctype,
     fields,
-    limit_page_length: input.limit ?? DEFAULT_LIMIT,
+    limit_page_length: coercedLimit ?? DEFAULT_LIMIT,
   };
   if (allFilters.length) args.filters = allFilters;
 

--- a/src/coerce.test.ts
+++ b/src/coerce.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { coerceStringArray, coerceObject, coerceNumber, coerceFilterArray } from "./coerce.js";
+
+describe("coerceStringArray", () => {
+  it("returns undefined for undefined/null", () => {
+    expect(coerceStringArray(undefined)).toBeUndefined();
+    expect(coerceStringArray(null)).toBeUndefined();
+  });
+
+  it("passes through string arrays", () => {
+    expect(coerceStringArray(["name", "item_code"])).toEqual(["name", "item_code"]);
+  });
+
+  it("parses JSON string arrays", () => {
+    expect(coerceStringArray('["name", "account_name"]')).toEqual(["name", "account_name"]);
+  });
+
+  it("wraps plain strings as single-element array", () => {
+    expect(coerceStringArray("name")).toEqual(["name"]);
+  });
+
+  it("returns undefined for non-array/string types", () => {
+    expect(coerceStringArray(42)).toBeUndefined();
+    expect(coerceStringArray({})).toBeUndefined();
+  });
+
+  it("rejects arrays with non-string elements", () => {
+    expect(coerceStringArray(["name", 42])).toBeUndefined();
+    expect(coerceStringArray([null, "name"])).toBeUndefined();
+    expect(coerceStringArray([true])).toBeUndefined();
+  });
+
+  it("returns empty array for empty array input", () => {
+    expect(coerceStringArray([])).toEqual([]);
+  });
+
+  it("rejects JSON string containing non-string array", () => {
+    expect(coerceStringArray("[1, 2, 3]")).toBeUndefined();
+  });
+});
+
+describe("coerceObject", () => {
+  it("returns undefined for undefined/null", () => {
+    expect(coerceObject(undefined)).toBeUndefined();
+    expect(coerceObject(null)).toBeUndefined();
+  });
+
+  it("passes through objects", () => {
+    expect(coerceObject({ account_number: "5205" })).toEqual({ account_number: "5205" });
+  });
+
+  it("parses JSON string objects", () => {
+    expect(coerceObject('{"account_number": "5205"}')).toEqual({ account_number: "5205" });
+  });
+
+  it("parses nested filter values", () => {
+    expect(coerceObject('{"name": ["like", "%5205%"]}')).toEqual({ name: ["like", "%5205%"] });
+  });
+
+  it("returns undefined for arrays", () => {
+    expect(coerceObject([1, 2, 3])).toBeUndefined();
+  });
+
+  it("returns undefined for JSON arrays in strings", () => {
+    expect(coerceObject('["name"]')).toBeUndefined();
+  });
+
+  it("returns undefined for invalid JSON strings", () => {
+    expect(coerceObject("not json")).toBeUndefined();
+  });
+
+  it("handles empty object string", () => {
+    expect(coerceObject("{}")).toEqual({});
+  });
+});
+
+describe("coerceNumber", () => {
+  it("returns undefined for undefined/null", () => {
+    expect(coerceNumber(undefined)).toBeUndefined();
+    expect(coerceNumber(null)).toBeUndefined();
+  });
+
+  it("passes through positive numbers", () => {
+    expect(coerceNumber(5)).toBe(5);
+    expect(coerceNumber(100)).toBe(100);
+  });
+
+  it("parses numeric strings", () => {
+    expect(coerceNumber("5")).toBe(5);
+    expect(coerceNumber("100")).toBe(100);
+  });
+
+  it("returns undefined for non-numeric strings", () => {
+    expect(coerceNumber("abc")).toBeUndefined();
+  });
+
+  it("returns undefined for empty/whitespace strings", () => {
+    expect(coerceNumber("")).toBeUndefined();
+    expect(coerceNumber("  ")).toBeUndefined();
+  });
+
+  it("rejects Infinity and NaN", () => {
+    expect(coerceNumber("Infinity")).toBeUndefined();
+    expect(coerceNumber(Infinity)).toBeUndefined();
+    expect(coerceNumber(NaN)).toBeUndefined();
+  });
+
+  it("accepts zero (means 'no limit' in Frappe)", () => {
+    expect(coerceNumber(0)).toBe(0);
+    expect(coerceNumber("0")).toBe(0);
+  });
+
+  it("rejects negative numbers", () => {
+    expect(coerceNumber(-5)).toBeUndefined();
+    expect(coerceNumber("-1")).toBeUndefined();
+  });
+});
+
+describe("coerceFilterArray", () => {
+  it("returns undefined for undefined/null", () => {
+    expect(coerceFilterArray(undefined)).toBeUndefined();
+    expect(coerceFilterArray(null)).toBeUndefined();
+  });
+
+  it("accepts valid filter arrays", () => {
+    const filters: [string, string, unknown][] = [["item_code", "like", "%CM5%"]];
+    expect(coerceFilterArray(filters)).toEqual(filters);
+  });
+
+  it("parses JSON string filter arrays", () => {
+    const json = '[["item_code", "like", "%CM5%"]]';
+    expect(coerceFilterArray(json)).toEqual([["item_code", "like", "%CM5%"]]);
+  });
+
+  it("rejects non-array values", () => {
+    expect(() => coerceFilterArray("not json")).toThrow("expected JSON array");
+    expect(() => coerceFilterArray(42)).toThrow("expected array");
+    expect(() => coerceFilterArray({})).toThrow("expected array");
+  });
+
+  it("accepts numeric filter values", () => {
+    expect(coerceFilterArray([["qty", ">", 10]])).toEqual([["qty", ">", 10]]);
+    expect(coerceFilterArray([["docstatus", "=", 1]])).toEqual([["docstatus", "=", 1]]);
+  });
+
+  it("rejects malformed filter entries", () => {
+    expect(() => coerceFilterArray([["field", "="]])).toThrow(
+      "expected [field, operator, value] triple",
+    );
+    expect(() => coerceFilterArray([["a", "b", "c", "d"]])).toThrow(
+      "expected [field, operator, value] triple",
+    );
+    expect(() => coerceFilterArray([[123, "=", "val"]])).toThrow(
+      "expected [field, operator, value] triple",
+    );
+    expect(() => coerceFilterArray([["field", 42, "val"]])).toThrow(
+      "expected [field, operator, value] triple",
+    );
+  });
+
+  it("accepts empty array", () => {
+    expect(coerceFilterArray([])).toEqual([]);
+  });
+});

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -1,0 +1,117 @@
+/**
+ * Input coercion for MCP tool arguments.
+ *
+ * The MCP SDK sometimes passes JSON-serialized strings instead of parsed
+ * objects/arrays. These helpers parse stringified inputs back to their
+ * expected types, preventing double-encoding when the values are later
+ * passed to JSON.stringify() for API calls.
+ */
+
+/**
+ * Coerce a value to a string array.
+ * Handles: undefined/null → undefined, string[] → pass-through,
+ * JSON string → parse, plain string → [string], other → undefined.
+ * Rejects arrays containing non-string elements.
+ */
+export function coerceStringArray(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (Array.isArray(value)) {
+    if (!value.every((v) => typeof v === "string")) return undefined;
+    return value;
+  }
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        // Parsed as array — only accept if all elements are strings
+        return parsed.every((v: unknown) => typeof v === "string") ? parsed : undefined;
+      }
+    } catch {
+      /* not JSON — wrap as single-element array below */
+    }
+    return [value];
+  }
+  return undefined;
+}
+
+/**
+ * Coerce a value to a plain object (Record<string, any>).
+ * Handles: undefined/null → undefined, object → pass-through,
+ * JSON string → parse, other → undefined.
+ */
+export function coerceObject(value: unknown): Record<string, any> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, any>;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) return parsed;
+    } catch {
+      /* not valid JSON object */
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Coerce a value to a finite non-negative number suitable for API limits.
+ * Zero is allowed (means "no limit" in Frappe). Negative and non-finite rejected.
+ * Handles: number → pass-through, numeric string → parse,
+ * undefined/null → undefined, other → undefined.
+ */
+export function coerceNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : undefined;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return undefined;
+    const n = Number(trimmed);
+    return Number.isFinite(n) && n >= 0 ? n : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Coerce a value to an array of [field, operator, value] filter triples.
+ * Field and operator must be strings; value can be any type (ERPNext accepts
+ * numeric values like [["qty", ">", 10]]).
+ * Handles: undefined/null → undefined, array → validate each element,
+ * JSON string → parse then validate, other → throw.
+ */
+export function coerceFilterArray(value: unknown): Array<[string, string, unknown]> | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  let arr: unknown;
+  if (typeof value === "string") {
+    try {
+      arr = JSON.parse(value);
+    } catch {
+      throw new Error(`Invalid child_filters: expected JSON array, got string`);
+    }
+  } else {
+    arr = value;
+  }
+
+  if (!Array.isArray(arr)) {
+    throw new Error(
+      `Invalid child_filters: expected array of [field, operator, value] triples, got ${typeof arr}`,
+    );
+  }
+
+  for (const filter of arr) {
+    if (
+      !Array.isArray(filter) ||
+      filter.length !== 3 ||
+      typeof filter[0] !== "string" ||
+      typeof filter[1] !== "string"
+    ) {
+      throw new Error(
+        `Invalid child_filter entry: expected [field, operator, value] triple, got ${JSON.stringify(filter)}`,
+      );
+    }
+  }
+
+  return arr as Array<[string, string, unknown]>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import axios, { AxiosInstance } from "axios";
 import { buildChildQueryArgs } from "./child-query.js";
+import { coerceStringArray, coerceObject, coerceNumber } from "./coerce.js";
 import { stripDocument } from "./strip.js";
 
 type AnyRecord = Record<string, any>;
@@ -108,11 +109,11 @@ class ERPNextClient {
   async getChildDocList(
     parentDoctype: string,
     childDoctype: string,
-    parentFields?: string[],
-    childFields?: string[],
-    childFilters?: Array<[string, string, string]>,
-    parentFilters?: AnyRecord,
-    limit?: number,
+    parentFields?: unknown,
+    childFields?: unknown,
+    childFilters?: unknown,
+    parentFilters?: unknown,
+    limit?: unknown,
   ): Promise<any[]> {
     const args = buildChildQueryArgs({
       parentDoctype,
@@ -644,9 +645,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new McpError(ErrorCode.InvalidParams, "Doctype is required");
       }
 
-      const fields = request.params.arguments?.fields as string[] | undefined;
-      const filters = request.params.arguments?.filters as AnyRecord | undefined;
-      const limit = request.params.arguments?.limit as number | undefined;
+      const fields = coerceStringArray(request.params.arguments?.fields);
+      const rawFilters = request.params.arguments?.filters;
+      const filters = coerceObject(rawFilters);
+      if (rawFilters != null && filters === undefined) {
+        throw new McpError(ErrorCode.InvalidParams, "filters must be a JSON object");
+      }
+      const limit = coerceNumber(request.params.arguments?.limit);
 
       try {
         const documents = await erpnext.getDocList(doctype, filters, fields, limit);
@@ -681,13 +686,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         );
       }
 
-      const parentFields = request.params.arguments?.parent_fields as string[] | undefined;
-      const childFields = request.params.arguments?.child_fields as string[] | undefined;
-      const childFilters = request.params.arguments?.child_filters as
-        | Array<[string, string, string]>
-        | undefined;
-      const parentFilters = request.params.arguments?.parent_filters as AnyRecord | undefined;
-      const limit = request.params.arguments?.limit as number | undefined;
+      const parentFields = request.params.arguments?.parent_fields;
+      const childFields = request.params.arguments?.child_fields;
+      const childFilters = request.params.arguments?.child_filters;
+      const parentFilters = request.params.arguments?.parent_filters;
+      const limit = request.params.arguments?.limit;
 
       try {
         const rows = await erpnext.getChildDocList(
@@ -717,7 +720,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case "create_document": {
       const doctype = request.params.arguments?.doctype;
-      const data = request.params.arguments?.data as AnyRecord | undefined;
+      const data = coerceObject(request.params.arguments?.data);
       if (typeof doctype !== "string" || !doctype || !data) {
         throw new McpError(ErrorCode.InvalidParams, "Doctype and data are required");
       }
@@ -753,7 +756,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case "update_document": {
       const doctype = request.params.arguments?.doctype;
       const name = request.params.arguments?.name;
-      const data = request.params.arguments?.data as AnyRecord | undefined;
+      const data = coerceObject(request.params.arguments?.data);
       if (typeof doctype !== "string" || !doctype || typeof name !== "string" || !name || !data) {
         throw new McpError(ErrorCode.InvalidParams, "Doctype, name, and data are required");
       }
@@ -792,7 +795,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new McpError(ErrorCode.InvalidParams, "Report name is required");
       }
 
-      const filters = request.params.arguments?.filters as AnyRecord | undefined;
+      const rawFilters = request.params.arguments?.filters;
+      const filters = coerceObject(rawFilters);
+      if (rawFilters != null && filters === undefined) {
+        throw new McpError(ErrorCode.InvalidParams, "filters must be a JSON object");
+      }
 
       try {
         const result = await erpnext.runReport(reportName, filters);
@@ -819,25 +826,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new McpError(ErrorCode.InvalidParams, "Doctype and name are required");
       }
 
-      const fields = request.params.arguments?.fields;
-      if (fields !== undefined && !Array.isArray(fields)) {
-        throw new McpError(ErrorCode.InvalidParams, "fields must be an array of strings");
-      }
+      const fields = coerceStringArray(request.params.arguments?.fields);
 
-      const childFields = request.params.arguments?.child_fields as
-        | Record<string, string[]>
-        | undefined;
-      if (childFields !== undefined) {
-        if (typeof childFields !== "object" || childFields === null) {
+      const rawChildFields = request.params.arguments?.child_fields;
+      let childFields: Record<string, string[]> | undefined;
+      if (rawChildFields !== undefined) {
+        const coerced = coerceObject(rawChildFields);
+        if (!coerced) {
           throw new McpError(ErrorCode.InvalidParams, "child_fields must be an object");
         }
-        for (const [key, value] of Object.entries(childFields)) {
-          if (!Array.isArray(value)) {
+        childFields = {} as Record<string, string[]>;
+        for (const [key, value] of Object.entries(coerced)) {
+          const arr = coerceStringArray(value);
+          if (!arr) {
             throw new McpError(
               ErrorCode.InvalidParams,
               `child_fields["${key}"] must be an array of strings`,
             );
           }
+          childFields[key] = arr;
         }
       }
 
@@ -866,7 +873,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new McpError(ErrorCode.InvalidParams, "Method is required");
       }
 
-      const args = request.params.arguments?.args as AnyRecord | undefined;
+      const rawArgs = request.params.arguments?.args;
+      const args = coerceObject(rawArgs);
+      if (rawArgs != null && args === undefined) {
+        throw new McpError(ErrorCode.InvalidParams, "args must be a JSON object");
+      }
       const httpMethod = (request.params.arguments?.http_method === "GET" ? "GET" : "POST") as
         | "GET"
         | "POST";


### PR DESCRIPTION
## Summary

- Add input coercion helpers (`coerceStringArray`, `coerceObject`, `coerceNumber`, `coerceFilterArray`) that parse JSON strings back to their expected types at the MCP tool handler boundary
- Apply coercion to **all** tool handlers in `index.ts`: `get_documents`, `get_child_documents`, `get_document`, `create_document`, `update_document`, `run_report`, `call_method`
- Widen `ChildQueryArgs` interface to accept `unknown` types, with coercion inside `buildChildQueryArgs`
- Comprehensive test coverage for all coercion helpers and stringified-input paths in `buildChildQueryArgs`

Closes #8, closes #9

Supersedes #10 and #12 (consolidates both into a single PR).

## Test plan

- [ ] All 70 tests pass (`npm test`)
- [ ] Lint clean (`npm run lint`)
- [ ] Prettier clean (`npm run format:check`)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual: verify `get_documents` with stringified filters no longer returns 417
- [ ] Manual: verify `get_child_documents` no longer crashes on stringified field arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)